### PR TITLE
add contrib ops to custom op checker context

### DIFF
--- a/onnxruntime_extensions/tools/pre_post_processing/utils.py
+++ b/onnxruntime_extensions/tools/pre_post_processing/utils.py
@@ -40,7 +40,7 @@ def create_custom_op_checker_context(onnx_opset: int):
     """
     context = onnx.checker.C.CheckerContext()
     context.ir_version = onnx.checker.DEFAULT_CONTEXT.ir_version
-    context.opset_imports = {"": onnx_opset, "com.microsoft.extensions": 1}
+    context.opset_imports = {"": onnx_opset, "com.microsoft.extensions": 1, "com.microsoft": 1}
 
     return context
 


### PR DESCRIPTION
This adds support for Contrib ops that may be used in a custom Step in a pre-post processing pipeline.